### PR TITLE
update icx_aaa_authentication

### DIFF
--- a/plugins/modules/icx_aaa_authentication.py
+++ b/plugins/modules/icx_aaa_authentication.py
@@ -17,7 +17,7 @@ notes:
   - Tested against ICX 10.1
 options:
   dot1x:
-    description: Enables 802.1X and MAC authentication.'none' method is not supported in 9.0.0 and 9.0.10
+    description: Enables 802.1X and MAC authentication."none" is not supported from 9.0.0
     default: null
     type: dict
     suboptions:
@@ -39,7 +39,7 @@ options:
     description: Configures the AAA authentication method for securing access to the Privileged EXEC level and global configuration levels of the CLI.
                  Only one of method-list or implicit-user should be provided. If the configured primary authentication fails due to an error,
                  the device tries the backup authentication methods in the order they appear in the list.
-                 Only local, radius and tacacs+ methods are supported in 9.0.10 and 9.0.0
+                 Only local, radius and tacacs+ methods are supported from 9.0.0
     default: null
     type: dict
     suboptions:
@@ -65,7 +65,7 @@ options:
   login:
     description: Configures the AAA authentication method for securing access to the Privileged EXEC level and global configuration levels of the CLI.
                  Only one of metod-list or implicit-user should be provided.
-                 Only local, radius, tacacs+ methods are supported in 9.0.10 and 9.0.0.
+                 Only local, radius, tacacs+ methods are supported from 9.0.0
     default: null
     type: dict
     suboptions:
@@ -89,7 +89,7 @@ options:
         choices: ['present', 'absent']
   snmp_server:
     description: Configures the AAA authentication method for SNMP server access.
-                 Only local, radius, tacacs+ methods are supported in 9.0.10 and 9.0.0.
+                 Only local, radius, tacacs+ methods are supported from 9.0.0
     default: null
     type: dict
     suboptions:
@@ -110,7 +110,7 @@ options:
         choices: ['present', 'absent']
   web_server:
     description: Configures the AAA authentication method to access the device through the Web Management Interface.
-                 Only local, radius, tacacs+ methods are supported in 9.0.10 and 9.0.0.
+                 Only local, radius, tacacs+ methods are supported from 9.0.0
     default: null
     type: dict
     suboptions:

--- a/plugins/modules/icx_aaa_authentication.py
+++ b/plugins/modules/icx_aaa_authentication.py
@@ -17,7 +17,7 @@ notes:
   - Tested against ICX 10.1
 options:
   dot1x:
-    description: Enables 802.1X and MAC authentication.
+    description: Enables 802.1X and MAC authentication.'none' method is not supported in 9.0.0 and 9.0.10
     default: null
     type: dict
     suboptions:
@@ -39,6 +39,7 @@ options:
     description: Configures the AAA authentication method for securing access to the Privileged EXEC level and global configuration levels of the CLI.
                  Only one of method-list or implicit-user should be provided. If the configured primary authentication fails due to an error,
                  the device tries the backup authentication methods in the order they appear in the list.
+                 Only local, radius and tacacs+ methods are supported in 9.0.10 and 9.0.0
     default: null
     type: dict
     suboptions:
@@ -64,6 +65,7 @@ options:
   login:
     description: Configures the AAA authentication method for securing access to the Privileged EXEC level and global configuration levels of the CLI.
                  Only one of metod-list or implicit-user should be provided.
+                 Only local, radius, tacacs+ methods are supported in 9.0.10 and 9.0.0.
     default: null
     type: dict
     suboptions:
@@ -87,6 +89,7 @@ options:
         choices: ['present', 'absent']
   snmp_server:
     description: Configures the AAA authentication method for SNMP server access.
+                 Only local, radius, tacacs+ methods are supported in 9.0.10 and 9.0.0.
     default: null
     type: dict
     suboptions:
@@ -107,6 +110,7 @@ options:
         choices: ['present', 'absent']
   web_server:
     description: Configures the AAA authentication method to access the device through the Web Management Interface.
+                 Only local, radius, tacacs+ methods are supported in 9.0.10 and 9.0.0.
     default: null
     type: dict
     suboptions:
@@ -179,10 +183,10 @@ def build_command(module, dot1x=None, enable=None, login=None, snmp_server=None,
                 cmd += " " + " ".join(enable['backup_method_list'])
             cmds.append(cmd)
         elif enable['implicit_user'] is not None:
-            if enable['state'] == 'absent':
-                cmd = "no aaa authentication enable implicit-user"
-            else:
+            if enable['implicit_user']:
                 cmd = "aaa authentication enable implicit-user"
+            else:
+                cmd = "no aaa authentication enable implicit-user"
             cmds.append(cmd)
 
     if login is not None:

--- a/plugins/modules/icx_aaa_authentication.py
+++ b/plugins/modules/icx_aaa_authentication.py
@@ -56,7 +56,6 @@ options:
         description: Configures the device to prompt only for a password when a user attempts to
                      gain Super User access to the Privileged EXEC and global configuration levels of the CLI.
         type: bool
-        default: false
       state:
         description: Specifies whether to configure or remove the authentication method.
         type: str
@@ -237,7 +236,7 @@ def main():
     enable_spec = dict(
         primary_method=dict(type='str', choices=['enable', 'line', 'local', 'radius', 'tacacs', 'tacacs+', 'none']),
         backup_method_list=dict(type='list', elements='str', choices=['enable', 'line', 'local', 'radius', 'tacacs', 'tacacs+', 'none']),
-        implicit_user=dict(type='bool', default=False),
+        implicit_user=dict(type='bool'),
         state=dict(type='str', default='present', choices=['present', 'absent'])
     )
     login_spec = dict(

--- a/tests/unit/plugins/modules/network/icx/test_icx_aaa_authentication.py
+++ b/tests/unit/plugins/modules/network/icx/test_icx_aaa_authentication.py
@@ -105,6 +105,20 @@ class TestICXAaaAuthenticationModule(TestICXModule):
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], expected_commands)
 
+    def test_icx_aaa_authentication_enable_implicit_user(self):
+        ''' Test for successful aaa authentication for enable implicit-user'''
+        set_module_args(dict(enable=dict(implicit_user=True)))
+        expected_commands = ['aaa authentication enable implicit-user']
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], expected_commands)
+
+    def test_icx_aaa_authentication_remove_enable_implicit_user(self):
+        ''' Test for removing aaa authentication for enable implicit-user'''
+        set_module_args(dict(enable=dict(implicit_user=False)))
+        expected_commands = ['no aaa authentication enable implicit-user']
+        result = self.execute_module(changed=True)
+        self.assertEqual(result['commands'], expected_commands)
+
     def test_icx_aaa_authentication_web_server(self):
         ''' Test for successful aaa authentication for web_server'''
         set_module_args(dict(web_server=dict(primary_method='tacacs', state='present')))


### PR DESCRIPTION
Fixed https://jira.ruckuswireless.com/browse/FI-245352 
(code is updated to fix the removal of enable with implicit_user and added test case).
Fixed https://jira.ruckuswireless.com/browse/FI-246144 (updated document about the options supported in 9.0 and 9.0.10)
